### PR TITLE
Add fillHoles and reconstruct functions.

### DIFF
--- a/modules/imgproc/doc/module.doc
+++ b/modules/imgproc/doc/module.doc
@@ -45,3 +45,8 @@
   \defgroup group_imgproc_contours Contours extraction
   Contours extraction.
 */
+/*!
+  \ingroup module_imgproc
+  \defgroup group_imgproc_morph Additional image morphology functions
+  Additional image morphology functions.
+*/

--- a/modules/imgproc/include/visp3/imgproc/vpImgproc.h
+++ b/modules/imgproc/include/visp3/imgproc/vpImgproc.h
@@ -1,7 +1,7 @@
 /****************************************************************************
  *
  * This file is part of the ViSP software.
- * Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+ * Copyright (C) 2005 - 2016 by Inria. All rights reserved.
  *
  * This software is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -36,7 +36,6 @@
  *****************************************************************************/
 
 
-
 /*!
   \file vpImgproc.h
   \brief Basic image processing functions.
@@ -47,6 +46,7 @@
 #define __vpImgproc_h__
 
 #include <visp3/core/vpImage.h>
+#include <visp3/core/vpImageMorphology.h>
 #include <visp3/imgproc/vpContours.h>
 
 
@@ -55,13 +55,6 @@ namespace vp
   enum RETINEX_LEVEL {
       RETINEX_UNIFORM = 0, RETINEX_LOW = 1, RETINEX_HIGH = 2
   };
-
-  typedef enum {
-    CONNECTED_CONNEXITY_4, /*!< For a given pixel 4 neighbors are considered (left,
-                      right, up, down) */
-    CONNECTED_CONNEXITY_8 /*!< For a given pixel 8 neighbors are considered (left,
-                     right, up, down, and the 4 pixels located on the diagonal) */
-  } vpConnectedConnexityType;
 
   VISP_EXPORT void adjust(vpImage<unsigned char> &I, const double alpha, const double beta);
   VISP_EXPORT void adjust(const vpImage<unsigned char> &I1, vpImage<unsigned char> &I2, const double alpha, const double beta);
@@ -99,7 +92,12 @@ namespace vp
       const unsigned int size=7, const double weight=0.6);
 
   VISP_EXPORT void connectedComponents(const vpImage<unsigned char> &I, vpImage<int> &labels, int &nbComponents,
-                                       const vpConnectedConnexityType &connexity=vp::CONNECTED_CONNEXITY_4);
+                                       const vpImageMorphology::vpConnexityType &connexity=vpImageMorphology::CONNEXITY_4);
+
+  VISP_EXPORT void fillHoles(vpImage<unsigned char> &I, const vpImageMorphology::vpConnexityType &connexity=vpImageMorphology::CONNEXITY_4);
+
+  VISP_EXPORT void reconstruct(const vpImage<unsigned char> &marker, const vpImage<unsigned char> &mask, vpImage<unsigned char> &I,
+                               const vpImageMorphology::vpConnexityType &connexity=vpImageMorphology::CONNEXITY_4);
 }
 
 #endif

--- a/modules/imgproc/src/vpConnectedComponents.cpp
+++ b/modules/imgproc/src/vpConnectedComponents.cpp
@@ -1,7 +1,7 @@
 /****************************************************************************
  *
  * This file is part of the ViSP software.
- * Copyright (C) 2005 - 2015 by Inria. All rights reserved.
+ * Copyright (C) 2005 - 2016 by Inria. All rights reserved.
  *
  * This software is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
@@ -46,10 +46,10 @@
 
 void getNeighbors(const vpImage<unsigned char> &I, std::queue<vpImagePoint> &listOfNeighbors,
                   const unsigned int i, const unsigned int j,
-                  const vp::vpConnectedConnexityType &connexity) {
+                  const vpImageMorphology::vpConnexityType &connexity) {
   unsigned char currValue = I[i][j];
 
-  if (connexity == vp::CONNECTED_CONNEXITY_4) {
+  if (connexity == vpImageMorphology::CONNEXITY_4) {
     //Top
     if (I[i-1][j] == currValue) {
       listOfNeighbors.push(vpImagePoint(i-1, j));
@@ -84,7 +84,7 @@ void getNeighbors(const vpImage<unsigned char> &I, std::queue<vpImagePoint> &lis
 }
 
 void visitNeighbors(vpImage<unsigned char> &I_copy, std::queue<vpImagePoint> &listOfNeighbors, vpImage<int> &labels,
-                    const int current_label, const vp::vpConnectedConnexityType &connexity) {
+                    const int current_label, const vpImageMorphology::vpConnexityType &connexity) {
   //Visit the neighbors
   while (!listOfNeighbors.empty()) {
     vpImagePoint imPt = listOfNeighbors.front();
@@ -112,8 +112,8 @@ void visitNeighbors(vpImage<unsigned char> &I_copy, std::queue<vpImagePoint> &li
   \param nbComponents : Number of connected components.
   \param connexity : Type of connexity.
 */
-void vp::connectedComponents(const vpImage<unsigned char> &I, vpImage<int> &labels,
-                             int &nbComponents, const vpConnectedConnexityType &connexity) {
+void vp::connectedComponents(const vpImage<unsigned char> &I, vpImage<int> &labels, int &nbComponents,
+                             const vpImageMorphology::vpConnexityType &connexity) {
   if (I.getSize() == 0) {
     return;
   }

--- a/modules/imgproc/src/vpContours.cpp
+++ b/modules/imgproc/src/vpContours.cpp
@@ -236,6 +236,7 @@ void getContoursList(const vp::vpContour &root, const int level, vp::vpContour &
 
   \param I : Grayscale image where we want to draw the input contours.
   \param contours : Detected contours.
+  \param grayValue : Drawing grayscale color.
 */
 void vp::drawContours(vpImage<unsigned char> &I, const std::vector<std::vector<vpImagePoint> > &contours, unsigned char grayValue) {
   if (I.getSize() == 0) {
@@ -279,7 +280,7 @@ void vp::drawContours(vpImage<vpRGBa> &I, const std::vector<std::vector<vpImageP
 
   Extract contours from a binary image.
 
-  \param I_original : Input image (0 means background, 1 means foreground, other values are not allowed).
+  \param I_original : Input binary image (0 means background, 1 means foreground, other values are not allowed).
   \param contours : Detected contours.
   \param contourPts : List of contours, each contour contains a list of contour points.
   \param retrievalMode : Contour retrieval mode.
@@ -432,4 +433,3 @@ void vp::findContours(const vpImage<unsigned char> &I_original, vpContour &conto
   delete root;
   root = NULL;
 }
-

--- a/modules/imgproc/src/vpMorph.cpp
+++ b/modules/imgproc/src/vpMorph.cpp
@@ -1,0 +1,139 @@
+/****************************************************************************
+ *
+ * This file is part of the ViSP software.
+ * Copyright (C) 2005 - 2016 by Inria. All rights reserved.
+ *
+ * This software is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * ("GPL") version 2 as published by the Free Software Foundation.
+ * See the file LICENSE.txt at the root directory of this source
+ * distribution for additional information about the GNU GPL.
+ *
+ * For using ViSP with software that can not be combined with the GNU
+ * GPL, please contact Inria about acquiring a ViSP Professional
+ * Edition License.
+ *
+ * See http://visp.inria.fr for more information.
+ *
+ * This software was developed at:
+ * Inria Rennes - Bretagne Atlantique
+ * Campus Universitaire de Beaulieu
+ * 35042 Rennes Cedex
+ * France
+ *
+ * If you have questions regarding the use of this file, please contact
+ * Inria at visp@inria.fr
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING THE
+ * WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Description:
+ * Additional image morphology functions.
+ *
+ * Authors:
+ * Souriya Trinh
+ *
+ *****************************************************************************/
+
+/*!
+  \file vpMorph.cpp
+  \brief Additional image morphology functions.
+*/
+
+#include <visp3/imgproc/vpImgproc.h>
+
+
+/*!
+  \ingroup group_imgproc_morph
+
+  Fill the holes in a binary image.
+
+  \param I : Input binary image (0 means background, 1 means foreground, other values are not allowed).
+  \param connexity : Type of connexity.
+*/
+void vp::fillHoles(vpImage<unsigned char> &I, const vpImageMorphology::vpConnexityType &connexity) {
+  if (I.getSize() == 0) {
+    return;
+  }
+
+  vpImage<unsigned char> mask(I.getHeight() + 2, I.getWidth() + 2, 255);
+  //Copy I to mask + add border padding + complement
+  for (unsigned int i = 0; i < I.getHeight(); i++) {
+    for (unsigned int j = 0; j < I.getWidth(); j++) {
+      mask[i+1][j+1] = 255 - I[i][j];
+    }
+  }
+
+  vpImage<unsigned char> marker(I.getHeight() + 2, I.getWidth() + 2, 0);
+  //Create marker with 255 1-pixel border
+  for (unsigned int i = 0; i < marker.getHeight(); i++) {
+    if (i == 0 || i == marker.getHeight()-1) {
+      for (unsigned int j = 0; j < marker.getWidth(); j++) {
+        marker[i][j] = 255;
+      }
+    } else {
+      marker[i][0] = 255;
+      marker[i][marker.getWidth()-1] = 255;
+    }
+  }
+
+  vpImage<unsigned char> I_reconstruct;
+  reconstruct(marker, mask, I_reconstruct, connexity);
+
+  for (unsigned int i = 0; i < I.getHeight(); i++) {
+    for (unsigned int j = 0; j < I.getWidth(); j++) {
+      I[i][j] = 255 - I_reconstruct[i+1][j+1];
+    }
+  }
+}
+
+/*!
+  \ingroup group_imgproc_morph
+
+  Perform morphological reconstruction of the image \a marker under the image \a mask.
+  Definition from Gleb V. Tcheslavsk:
+  > The morphological reconstruction by dilation of a grayscale image \f$ g \f$ by a grayscale marker image \f$ f \f$
+  > is defined as the geodesic dilation of \f$ f \f$ with respect to \f$ g \f$ repeated (iterated) until stability is reached:
+  \f[
+    R_{g}^{D} \left ( f \right ) = D_{g}^{\left ( k \right )} \left ( f \right )
+  \f]
+  with \f$ k \f$ such that: \f$ D_{g}^{\left ( k \right )} \left ( f \right ) = D_{g}^{\left ( k+1 \right )} \left ( f \right ) \f$
+
+  \param marker : Grayscale image marker.
+  \param mask : Grayscale image mask.
+  \param h_kp1 : Image morphologically reconstructed.
+  \param connexity : Type of connexity.
+*/
+void vp::reconstruct(const vpImage<unsigned char> &marker, const vpImage<unsigned char> &mask, vpImage<unsigned char> &h_kp1 /*alias I */,
+                const vpImageMorphology::vpConnexityType &connexity) {
+  if (marker.getHeight() != mask.getHeight() || marker.getWidth() != mask.getWidth()) {
+    std::cerr << "marker.getHeight() != mask.getHeight() || marker.getWidth() != mask.getWidth()" << std::endl;
+    return;
+  }
+
+  if (marker.getSize() == 0) {
+    std::cerr << "Input images are empty!" << std::endl;
+    return;
+  }
+
+  vpImage<unsigned char> h_k = marker;
+  h_kp1 = h_k;
+
+  do {
+    //Dilatation
+    vpImageMorphology::dilatation(h_kp1, connexity);
+
+    //Keep min
+    for (unsigned int i = 0; i < h_kp1.getHeight(); i++) {
+      for (unsigned int j = 0; j < h_kp1.getWidth(); j++) {
+        h_kp1[i][j] = std::min(h_kp1[i][j], mask[i][j]);
+      }
+    }
+
+    if (h_kp1 == h_k) {
+      break;
+    }
+
+    h_k = h_kp1;
+  } while (true);
+}

--- a/modules/imgproc/test/testConnectedComponents.cpp
+++ b/modules/imgproc/test/testConnectedComponents.cpp
@@ -238,7 +238,7 @@ main(int argc, const char ** argv)
     vpImage<int> labels_connex4;
     int nbComponents = 0;
     double t = vpTime::measureTimeMs();
-    vp::connectedComponents(I, labels_connex4, nbComponents, vp::CONNECTED_CONNEXITY_4);
+    vp::connectedComponents(I, labels_connex4, nbComponents, vpImageMorphology::CONNEXITY_4);
     t = vpTime::measureTimeMs() - t;
     std::cout << "\n4-connexity connected components:" << std::endl;
     std::cout << "Time: " << t << " ms" << std::endl;
@@ -246,7 +246,7 @@ main(int argc, const char ** argv)
 
     vpImage<int> labels_connex8;
     t = vpTime::measureTimeMs();
-    vp::connectedComponents(I, labels_connex8, nbComponents, vp::CONNECTED_CONNEXITY_8);
+    vp::connectedComponents(I, labels_connex8, nbComponents, vpImageMorphology::CONNEXITY_8);
     t = vpTime::measureTimeMs() - t;
     std::cout << "\n8-connexity connected components:" << std::endl;
     std::cout << "Time: " << t << " ms" << std::endl;

--- a/modules/imgproc/test/testContours.cpp
+++ b/modules/imgproc/test/testContours.cpp
@@ -378,6 +378,22 @@ main(int argc, const char ** argv)
     vpImageIo::write(I_draw_contours_external, filename);
 
 
+    //Test fillHoles
+    vpImage<unsigned char> I_holes = I_draw_contours_external;
+    vpImageTools::binarise(I_holes, (unsigned char) 127, (unsigned char) 255, (unsigned char) 0, (unsigned char) 1, (unsigned char) 1);
+
+    t = vpTime::measureTimeMs();
+    vp::fillHoles(I_holes);
+    t = vpTime::measureTimeMs() - t;
+    std::cout << "\nFill Holes: " << t << " ms" << std::endl;
+    for (unsigned int cpt = 0; cpt < I_holes.getSize(); cpt++) {
+      I_holes.bitmap[cpt] *= 255;
+    }
+
+    filename = vpIoTools::createFilePath(opath, "Klimt_contours_extracted_external_fill_holes.pgm");
+    vpImageIo::write(I_holes, filename);
+
+
 #if VISP_HAVE_OPENCV_VERSION >= 0x030000
     cv::Mat matImg;
     vpImageConvert::convert(I, matImg);


### PR DESCRIPTION
Input binary image:
![i_contours_extracted_external](https://cloud.githubusercontent.com/assets/8035162/19001800/530863c4-8749-11e6-9def-502a9b9966aa.png)

Image after fillHoles call:
![i_contours_extracted_external_fill_holes](https://cloud.githubusercontent.com/assets/8035162/19001849/8b02f712-8749-11e6-8ff6-99771bd6d313.png)

---

Fill holes implementation is naïve and takes lots of time.