### PR TITLE
Fix Klimt image path

### DIFF
--- a/modules/imgproc_contrib/test/testImgproc-deprecated.cpp
+++ b/modules/imgproc_contrib/test/testImgproc-deprecated.cpp
@@ -83,7 +83,7 @@ SYNOPSIS\n\
 OPTIONS:                                               Default\n\
   -i <input image path>                                %s\n\
      Set image input path.\n\
-     From this path read \"ViSP-images/Klimt/Klimt.pgm\"\n\
+     From this path read \"Klimt/Klimt.pgm\"\n\
      image.\n\
      Setting the VISP_INPUT_IMAGE_PATH environment\n\
      variable produces the same behaviour than using\n\
@@ -249,7 +249,7 @@ main(int argc, const char ** argv)
     //
 
     //Read Klimt.ppm
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/Klimt/Klimt.ppm");
+    filename = vpIoTools::createFilePath(ipath, "Klimt/Klimt.ppm");
     vpImage<vpRGBa> I_color;
     std::cout << "Read image: " << filename << std::endl;
     vpImageIo::read(I_color, filename);
@@ -348,7 +348,7 @@ main(int argc, const char ** argv)
     //
 
     //Read image0000.pgm
-    filename = vpIoTools::createFilePath(ipath, "ViSP-images/mbt/cube/image0000.pgm");
+    filename = vpIoTools::createFilePath(ipath, "mbt/cube/image0000.pgm");
     vpImage<unsigned char> I;
     std::cout << "\nRead image: " << filename << std::endl;
     vpImageIo::read(I, filename);


### PR DESCRIPTION
See:
- https://github.com/lagadic/visp/pull/1969
- https://github.com/lagadic/visp/pull/253

```bash
Read image: /home/runner/visp-images/ViSP-images/Klimt/Klimt.ppm
Catch an exception: Cannot read file: "/home/runner/visp-images/ViSP-images/Klimt/Klimt.ppm" doesn't exist
```